### PR TITLE
Fix ActiveRecord 5 compatibility

### DIFF
--- a/lib/static_models.rb
+++ b/lib/static_models.rb
@@ -36,7 +36,7 @@ module StaticModels
       def valid?
         true
       end
-      
+
       # For compatibility with AR relations in ActiveAdmin and others.
       # Feel free to override this.
       def self.where(*args)
@@ -111,6 +111,13 @@ module StaticModels
           values[item.id] = item
           raise ValueError.new if singleton_methods.include?(item.code)
           define_singleton_method(item.code){ item }
+        end
+
+        def arel_table
+          @arel_table ||= begin
+                            table_name = self.to_s.split('::').map(&:underscore).map(&:pluralize).join('_')
+                            Arel::Table.new(table_name, type_caster: ::StaticModels::FakeTypeCaster.new)
+                          end
         end
       end
 
@@ -199,6 +206,12 @@ module StaticModels
             instance_variable_get("@invalid_#{association}_code")
         end
       end
+    end
+  end
+
+  class FakeTypeCaster
+    def type_cast_for_database(_attr_name, value)
+      value
     end
   end
 

--- a/lib/static_models/version.rb
+++ b/lib/static_models/version.rb
@@ -1,3 +1,3 @@
 module StaticModels
-  VERSION = "0.4.8"
+  VERSION = "0.4.9"
 end

--- a/lib/static_models/version.rb
+++ b/lib/static_models/version.rb
@@ -1,3 +1,3 @@
 module StaticModels
-  VERSION = "0.4.9"
+  VERSION = "0.5.0"
 end

--- a/spec/static_models_spec.rb
+++ b/spec/static_models_spec.rb
@@ -368,6 +368,10 @@ describe StaticModels::BelongsTo do
       dog.update(anything: dog)
       dog.should be_valid
     end
+
+    it 'can be used in queries' do
+      expect(StoreDog.where(breed: Breed.collie).count).to be_zero
+    end
   end
 
   it "has a code accessor useful for validations" do


### PR DESCRIPTION
Queries such as:

```
RealActiveRecordModel.where(static_model: static_model_instance)
```

Break because the PredicateQueryBuilder expects `arel_table` method to be defined.

This intends to fix that at least for this scenario.

Has https://github.com/bitex-la/static_models/pull/13 branch in it.